### PR TITLE
feat: update github node to 22

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Install Dependencies
         run: |
           yarn global add hexo-cli


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Pages workflow to Node 22, upgrades GitHub Actions, and adds a dedicated deploy job for GitHub Pages.
> 
> - **CI — `/.github/workflows/pages.yml`**:
>   - **Runtime**: Switch to Node.js `22` using `actions/setup-node@v4` (from `18`/`@v3`).
>   - **Actions Upgrades**: Bump to `actions/checkout@v4`; use `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`.
>   - **Deploy**: Add a `deploy` job with `pages`/`id-token` permissions and environment config; deploy via `actions/deploy-pages@v4`.
>   - **Artifacts**: Set upload path to `./public`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 750f6421e209a3ec8d8a3937dd445717b5e02bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->